### PR TITLE
Add custom variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Whether running via the command line or from a script, the arguments and options
     * %%FILENAME%% - Filename of the source file without the extension
     * %%EXT%% - Extension excluding the period of the file (e.g. ui or qrc)
     * %%DIRNAME%% - Directory of the source file
+* **variables** - custom variables that can be used in the definition of the paths in **ioPaths**. For example, to limit the search of files to a specific directory, one can define a variable `BASEDIR` and then use it as `%%BASEDIR%%/gui/*.ui*`
 
 Example
 =======
@@ -101,10 +102,10 @@ Take the following file structure as an example project where any UI and QRC fil
 |   `-- style.qrc
 |-- modules
 |   |-- welcome
-|       |-- module.ui
-|       `-- resources
-|           |-- images
-|           `-- module.qrc
+|   |   |-- module.ui
+|   |   `-- resources
+|   |       |-- images
+|   |       `-- module.qrc
 |   `-- dataProbe
 |       |-- module.ui
 |       `-- resources

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -139,7 +139,7 @@ def replaceVariables(variables_definition, string_with_variables):
     return string_with_variables
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables=None):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -158,8 +158,10 @@ def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), varia
             variables = configData.get('variables', variables)
 
     # Validate the custom variables
+    if variables is None:
+        variables = {}
     if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
-        raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
+        raise ValueError("Custom variables cannot be called FILENAME, EXT or DIRNAME.")
 
     # Loop through the list of io paths
     for sourceFileExpr, destFileExpr in ioPaths:

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -187,6 +187,8 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             filename, ext = os.path.splitext(basename)
 
             # Replace instances of the variables with the actual values from the source filename
+            if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
+                raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -159,6 +159,10 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             ioPaths = configData.get('ioPaths', ioPaths)
             variables = configData.get('variables', variables)
 
+    # Validate the custom variables
+    if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
+        raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
+
     # Loop through the list of io paths
     for sourceFileExpr, destFileExpr in ioPaths:
         foundItem = False
@@ -187,8 +191,6 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             filename, ext = os.path.splitext(basename)
 
             # Replace instances of the variables with the actual values from the source filename
-            if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
-                raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -72,11 +72,9 @@ def _isOutdated(src, dst, isQRCFile):
 @click.option('--config', '-c', default='', type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help='JSON or YAML file containing the configuration parameters')
 @click.option('--force', default=False, is_flag=True, help='Compile all files regardless of last modification time')
-@click.option('--no_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
-                                                            '(add an empty __init__.py)')
 @click.argument('iopaths', nargs=-1, required=False)
 @click.version_option(__version__)
-def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
+def cli(rccOptions, uicOptions, force, config, iopaths=()):
     """Compile PyQt5 UI/QRC files into Python
 
     IOPATHS argument is a space delineated pair of glob expressions that specify the source files to compile as the
@@ -124,7 +122,7 @@ def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
     # second column the destination file expression.
     ioPaths = list(zip(iopaths[::2], iopaths[1::2]))
 
-    main(rccOptions, uicOptions, force, config, no_init, ioPaths)
+    main(rccOptions, uicOptions, force, config, ioPaths)
 
 
 def replaceVariables(variables_definition, string_with_variables):
@@ -141,7 +139,7 @@ def replaceVariables(variables_definition, string_with_variables):
     return string_with_variables
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables={}):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -213,10 +211,6 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
 
             # Create all directories to the destination filename and do nothing if they already exist
             os.makedirs(os.path.dirname(destFilename), exist_ok=True)
-
-            if no_init:
-                with open(os.path.join(os.path.dirname(destFilename), "__init__.py"), 'w'):
-                    pass
 
             # If we are force compiling everything or the source file is outdated, then compile, otherwise skip!
             if force or _isOutdated(sourceFilename, destFilename, isQRCFile):

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -72,11 +72,11 @@ def _isOutdated(src, dst, isQRCFile):
 @click.option('--config', '-c', default='', type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help='JSON or YAML file containing the configuration parameters')
 @click.option('--force', default=False, is_flag=True, help='Compile all files regardless of last modification time')
-@click.option('--ensure_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
+@click.option('--no_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
                                                                 '(add an empty __init__.py)')
 @click.argument('iopaths', nargs=-1, required=False)
 @click.version_option(__version__)
-def cli(rccOptions, uicOptions, force, config, ensure_init, iopaths=()):
+def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
     """Compile PyQt5 UI/QRC files into Python
 
     IOPATHS argument is a space delineated pair of glob expressions that specify the source files to compile as the
@@ -124,10 +124,10 @@ def cli(rccOptions, uicOptions, force, config, ensure_init, iopaths=()):
     # second column the destination file expression.
     ioPaths = list(zip(iopaths[::2], iopaths[1::2]))
 
-    main(rccOptions, uicOptions, force, config, ensure_init, ioPaths)
+    main(rccOptions, uicOptions, force, config, no_init, ioPaths)
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', ensure_init=True, ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, ioPaths=(), variables={}):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -199,7 +199,7 @@ def main(rccOptions='', uicOptions='', force=False, config='', ensure_init=True,
             # Create all directories to the destination filename and do nothing if they already exist
             os.makedirs(os.path.dirname(destFilename), exist_ok=True)
 
-            if ensure_init:
+            if no_init:
                 with open(os.path.join(os.path.dirname(destFilename), "__init__.py"), 'w'):
                     pass
 


### PR DESCRIPTION
As for the title, add support for custom variables, as discussed in #2.
In addition (sorry for sneaking the feature in...) makes sure the target folder for the generated files contains a `__init__.py` file, generating it at need. This feature can be disabled by setting the `--no_init` flag.