### PR TITLE
Resolving relative paths from the configuration file #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Whether running via the command line or from a script, the arguments and options
 * **variables** - custom variables that can be used in the definition of the paths in **ioPaths**. For example, to limit the search of files to a specific directory, one can define a variable `BASEDIR` and then use it as `%%BASEDIR%%/gui/*.ui*`
 * **init_package** - If specified, an empty `__init__.py` file is also generated in every output directory if missing. Does not overwrite existing `__init__.py`. Default value is `True`.
 
+Note that all relative paths are resolved from the configuration file location, if given through a config file, or from the current working directory otherwise.
+
 Example
 =======
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Whether running via the command line or from a script, the arguments and options
     * %%FILENAME%% - Filename of the source file without the extension
     * %%EXT%% - Extension excluding the period of the file (e.g. ui or qrc)
     * %%DIRNAME%% - Directory of the source file
+* **variables** - custom variables that can be used in the definition of the paths in **ioPaths**. For example, to limit the search of files to a specific directory, one can define a variable `BASEDIR` and then use it as `%%BASEDIR%%/gui/*.ui*`
 
 Example
 =======
@@ -101,10 +102,10 @@ Take the following file structure as an example project where any UI and QRC fil
 |   `-- style.qrc
 |-- modules
 |   |-- welcome
-|       |-- module.ui
-|       `-- resources
-|           |-- images
-|           `-- module.qrc
+|   |   |-- module.ui
+|   |   `-- resources
+|   |       |-- images
+|   |       `-- module.qrc
 |   `-- dataProbe
 |       |-- module.ui
 |       `-- resources

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -139,7 +139,7 @@ def replaceVariables(variables_definition, string_with_variables):
     return string_with_variables
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables=None):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -158,8 +158,10 @@ def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), varia
             variables = configData.get('variables', variables)
 
     # Validate the custom variables
+    if variables is None:
+        variables = {}
     if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
-        raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
+        raise ValueError("Custom variables cannot be called FILENAME, EXT or DIRNAME.")
 
     # Loop through the list of io paths
     for sourceFileExpr, destFileExpr in ioPaths:

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -187,6 +187,8 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             filename, ext = os.path.splitext(basename)
 
             # Replace instances of the variables with the actual values from the source filename
+            if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
+                raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -149,12 +149,15 @@ def resolvePath(path: str, reference_path: str) -> str:
     Meaningful reference values for the caller might be the configuration file path, the script's path or the current
     working directory.
     :param path: path to resolve.
-    :param reference_path: path to be used as a reference to servole absolute paths
+    :param reference_path: path to be used as a reference to resolve absolute paths
     :return: an absolute path corresponding to the relative path passed in input if it was relative, or the unchanged
     input if it was an absolute path.
+    :raises: ValueError if the reference path is not absolute
     """
     if not os.path.isabs(path):
-        return os.path.join(os.path.dirname(os.path.realpath(reference_path)), path)
+        if not os.path.isabs(reference_path):
+            raise ValueError("The reference path must be absolute.")
+        return os.path.join(reference_path, path)
     return path
 
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -159,6 +159,10 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             ioPaths = configData.get('ioPaths', ioPaths)
             variables = configData.get('variables', variables)
 
+    # Validate the custom variables
+    if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
+        raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
+
     # Loop through the list of io paths
     for sourceFileExpr, destFileExpr in ioPaths:
         foundItem = False
@@ -187,8 +191,6 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
             filename, ext = os.path.splitext(basename)
 
             # Replace instances of the variables with the actual values from the source filename
-            if 'FILENAME' in variables.keys() or 'EXT' in variables.keys() or 'DIRNAME' in variables.keys():
-                raise ValueError("Custom variables cannot be called FILENAME EXT OR DIRNAME.")
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -72,11 +72,9 @@ def _isOutdated(src, dst, isQRCFile):
 @click.option('--config', '-c', default='', type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help='JSON or YAML file containing the configuration parameters')
 @click.option('--force', default=False, is_flag=True, help='Compile all files regardless of last modification time')
-@click.option('--no_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
-                                                            '(add an empty __init__.py)')
 @click.argument('iopaths', nargs=-1, required=False)
 @click.version_option(__version__)
-def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
+def cli(rccOptions, uicOptions, force, config, iopaths=()):
     """Compile PyQt5 UI/QRC files into Python
 
     IOPATHS argument is a space delineated pair of glob expressions that specify the source files to compile as the
@@ -124,7 +122,7 @@ def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
     # second column the destination file expression.
     ioPaths = list(zip(iopaths[::2], iopaths[1::2]))
 
-    main(rccOptions, uicOptions, force, config, no_init, ioPaths)
+    main(rccOptions, uicOptions, force, config, ioPaths)
 
 
 def replaceVariables(variables_definition, string_with_variables):
@@ -141,7 +139,7 @@ def replaceVariables(variables_definition, string_with_variables):
     return string_with_variables
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables={}):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -213,10 +211,6 @@ def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, io
 
             # Create all directories to the destination filename and do nothing if they already exist
             os.makedirs(os.path.dirname(destFilename), exist_ok=True)
-
-            if no_init:
-                with open(os.path.join(os.path.dirname(destFilename), "__init__.py"), 'w'):
-                    pass
 
             # If we are force compiling everything or the source file is outdated, then compile, otherwise skip!
             if force or _isOutdated(sourceFilename, destFilename, isQRCFile):

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -143,6 +143,21 @@ def replaceVariables(variables_definition, string_with_variables):
     return string_with_variables
 
 
+def resolvePath(path: str, reference_path: str) -> str:
+    """
+    Translates relative paths into absolute paths, using the reference path as base.
+    Meaningful reference values for the caller might be the configuration file path, the script's path or the current
+    working directory.
+    :param path: path to resolve.
+    :param reference_path: path to be used as a reference to servole absolute paths
+    :return: an absolute path corresponding to the relative path passed in input if it was relative, or the unchanged
+    input if it was an absolute path.
+    """
+    if not os.path.isabs(path):
+        return os.path.join(os.path.dirname(os.path.realpath(reference_path)), path)
+    return path
+
+
 def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), variables=None, initPackage=True):
     if config:
         with open(config, 'r') as fh:
@@ -201,8 +216,9 @@ def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), varia
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 
-            # Retrieve the absolute path to the source and destination filename
-            sourceFilename, destFilename = os.path.abspath(sourceFilename), os.path.abspath(destFilename)
+            # Retrieve the absolute path to the source and destination files
+            sourceFilename = resolvePath(sourceFilename, (config or os.getcwd()))
+            destFilename = resolvePath(destFilename, (config or os.getcwd()))
 
             if ext == '.ui':
                 isQRCFile = False

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -72,11 +72,11 @@ def _isOutdated(src, dst, isQRCFile):
 @click.option('--config', '-c', default='', type=click.Path(exists=True, file_okay=True, dir_okay=False),
               help='JSON or YAML file containing the configuration parameters')
 @click.option('--force', default=False, is_flag=True, help='Compile all files regardless of last modification time')
-@click.option('--ensure_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
+@click.option('--no_init', default=True, is_flag=True, help='Ensures that eventual new folders are Python modules '
                                                                 '(add an empty __init__.py)')
 @click.argument('iopaths', nargs=-1, required=False)
 @click.version_option(__version__)
-def cli(rccOptions, uicOptions, force, config, ensure_init, iopaths=()):
+def cli(rccOptions, uicOptions, force, config, no_init, iopaths=()):
     """Compile PyQt5 UI/QRC files into Python
 
     IOPATHS argument is a space delineated pair of glob expressions that specify the source files to compile as the
@@ -124,10 +124,10 @@ def cli(rccOptions, uicOptions, force, config, ensure_init, iopaths=()):
     # second column the destination file expression.
     ioPaths = list(zip(iopaths[::2], iopaths[1::2]))
 
-    main(rccOptions, uicOptions, force, config, ensure_init, ioPaths)
+    main(rccOptions, uicOptions, force, config, no_init, ioPaths)
 
 
-def main(rccOptions='', uicOptions='', force=False, config='', ensure_init=True, ioPaths=(), variables={}):
+def main(rccOptions='', uicOptions='', force=False, config='', no_init=False, ioPaths=(), variables={}):
     if config:
         with open(config, 'r') as fh:
             if config.endswith('.yml'):
@@ -199,7 +199,7 @@ def main(rccOptions='', uicOptions='', force=False, config='', ensure_init=True,
             # Create all directories to the destination filename and do nothing if they already exist
             os.makedirs(os.path.dirname(destFilename), exist_ok=True)
 
-            if ensure_init:
+            if no_init:
                 with open(os.path.join(os.path.dirname(destFilename), "__init__.py"), 'w'):
                     pass
 

--- a/pyqt5ac.py
+++ b/pyqt5ac.py
@@ -195,6 +195,9 @@ def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), varia
         # Replace instances of the variables with the actual values of the available variables
         sourceFileExpr = replaceVariables(variables, sourceFileExpr)
 
+        # Retrieve the absolute path to the source files
+        sourceFileExpr = resolvePath(sourceFileExpr, (os.path.dirname(config) or os.getcwd()))
+
         # Find files that match the source filename expression given
         for sourceFilename in glob.glob(sourceFileExpr, recursive=True):
             # If the filename does not exist, not sure why this would ever occur, but show a warning
@@ -219,9 +222,8 @@ def main(rccOptions='', uicOptions='', force=False, config='', ioPaths=(), varia
             variables.update({'FILENAME': filename, 'EXT': ext[1:], 'DIRNAME': dirname})
             destFilename = replaceVariables(variables, destFileExpr)
 
-            # Retrieve the absolute path to the source and destination files
-            sourceFilename = resolvePath(sourceFilename, (config or os.getcwd()))
-            destFilename = resolvePath(destFilename, (config or os.getcwd()))
+            # Retrieve the absolute path to the destination files
+            destFilename = resolvePath(destFilename, (os.path.dirname(config) or os.getcwd()))
 
             if ext == '.ui':
                 isQRCFile = False

--- a/tests/test_pyqt5ac.py
+++ b/tests/test_pyqt5ac.py
@@ -307,3 +307,17 @@ def test_dont_check_for_init(tmpdir):
     _assert_path_exists(tmpdir.join("generated"))
     _assert_path_exists(tmpdir.join("generated/main_ui.py"))
     _assert_path_does_not_exist(tmpdir.join("generated/__init__.py"))
+
+
+def test_can_find_files_if_called_from_another_directory(tmpdir):
+    config = _write_config_file(tmpdir)
+    ui_file = tmpdir.mkdir("gui").join("main.ui")
+    _write_ui_file(ui_file)
+
+    tmpdir.mkdir("another_directory")
+    os.chdir(tmpdir.join("another_directory"))
+    pyqt5ac.main(config=str(config), initPackage=False)
+
+    _assert_path_exists(tmpdir.join("generated"))
+    _assert_path_exists(tmpdir.join("generated/main_ui.py"))
+    _assert_path_does_not_exist(tmpdir.join("generated/__init__.py"))

--- a/tests/test_pyqt5ac.py
+++ b/tests/test_pyqt5ac.py
@@ -309,7 +309,7 @@ def test_dont_check_for_init(tmpdir):
     _assert_path_does_not_exist(tmpdir.join("generated/__init__.py"))
 
 
-def test_can_find_files_if_called_from_another_directory_using_config_file(tmpdir):
+def test_relative_paths_are_relative_to_their_config_file(tmpdir):
     config = _write_config_file(tmpdir)
     ui_file = tmpdir.mkdir("gui").join("main.ui")
     _write_ui_file(ui_file)
@@ -322,25 +322,54 @@ def test_can_find_files_if_called_from_another_directory_using_config_file(tmpdi
     _assert_path_exists(tmpdir.join("generated/main_ui.py"))
 
 
-def test_can_find_files_if_called_from_another_directory_without_config_file(tmpdir):
+def test_relative_paths_are_relative_to_cwd_if_no_config_file_is_given(tmpdir):
     ui_file = tmpdir.mkdir("another_directory").mkdir("gui").join("main.ui")
     _write_ui_file(ui_file)
     os.chdir(str(tmpdir.join("another_directory")))  # Python3.5 compatibility
 
     pyqt5ac.main(uicOptions='--from-imports', force=False, initPackage=True, ioPaths=[
         ['gui/*.ui', 'generated/%%FILENAME%%_ui.py'],
-        ['resources/*.qrc', 'generated/%%FILENAME%%_rc.py'],
-        ['modules/*/*.ui', '%%DIRNAME%%/generated/%%FILENAME%%_ui.py'],
-        ['modules/*/resources/*.qrc', '%%DIRNAME%%/generated/%%FILENAME%%_rc.py']
     ])
 
     _assert_path_does_not_exist(tmpdir.join("generated"))
     _assert_path_does_not_exist(tmpdir.join("generated/main_ui.py"))
-
     _assert_path_exists(tmpdir.join("another_directory").join("generated"))
     _assert_path_exists(tmpdir.join("another_directory").join("generated/main_ui.py"))
 
 
+def test_absolute_paths_stay_untouched(tmpdir):
+    dir1 = tmpdir.mkdir("dir1")
+    dir2 = tmpdir.mkdir("dir2")
+    dir3 = tmpdir.mkdir("dir3")
 
+    ui_file = dir2.mkdir("gui").join("main.ui")
+    _write_ui_file(ui_file)
+
+    os.chdir(str(dir1))  # Python3.5 compatibility
+    pyqt5ac.main(uicOptions='--from-imports', force=False, initPackage=True, ioPaths=[
+        [str(dir2.join('gui/*.ui')), str(dir3.join('generated/%%FILENAME%%_ui.py'))],
+    ])
+
+    _assert_path_does_not_exist(tmpdir.join("generated"))
+    _assert_path_does_not_exist(tmpdir.join("generated/main_ui.py"))
+    _assert_path_exists(dir3.join("generated"))
+    _assert_path_exists(dir3.join("generated/main_ui.py"))
+
+
+def test_config_file_path_is_relative_to_cwd(tmpdir):
+    another_dir = tmpdir.mkdir("another_directory")
+    _write_config_file(another_dir)
+    ui_file = another_dir.mkdir("gui").join("main.ui")
+    _write_ui_file(ui_file)
+
+    os.chdir(str(another_dir))  # Python3.5 compatibility
+    pyqt5ac.main(config="input_config.yml")
+
+    _assert_path_exists(another_dir.join("generated"))
+    _assert_path_exists(another_dir.join("generated/main_ui.py"))
+
+    os.chdir(str(tmpdir))  # Python3.5 compatibility
+    with pytest.raises(FileNotFoundError):
+        pyqt5ac.main(config="input_config.yml")
 
 

--- a/tests/test_pyqt5ac.py
+++ b/tests/test_pyqt5ac.py
@@ -309,15 +309,38 @@ def test_dont_check_for_init(tmpdir):
     _assert_path_does_not_exist(tmpdir.join("generated/__init__.py"))
 
 
-def test_can_find_files_if_called_from_another_directory(tmpdir):
+def test_can_find_files_if_called_from_another_directory_using_config_file(tmpdir):
     config = _write_config_file(tmpdir)
     ui_file = tmpdir.mkdir("gui").join("main.ui")
     _write_ui_file(ui_file)
-
     tmpdir.mkdir("another_directory")
-    os.chdir(tmpdir.join("another_directory"))
-    pyqt5ac.main(config=str(config), initPackage=False)
+    os.chdir(str(tmpdir.join("another_directory")))  # Python3.5 compatibility
+
+    pyqt5ac.main(config=str(config))
 
     _assert_path_exists(tmpdir.join("generated"))
     _assert_path_exists(tmpdir.join("generated/main_ui.py"))
-    _assert_path_does_not_exist(tmpdir.join("generated/__init__.py"))
+
+
+def test_can_find_files_if_called_from_another_directory_without_config_file(tmpdir):
+    ui_file = tmpdir.mkdir("another_directory").mkdir("gui").join("main.ui")
+    _write_ui_file(ui_file)
+    os.chdir(str(tmpdir.join("another_directory")))  # Python3.5 compatibility
+
+    pyqt5ac.main(uicOptions='--from-imports', force=False, initPackage=True, ioPaths=[
+        ['gui/*.ui', 'generated/%%FILENAME%%_ui.py'],
+        ['resources/*.qrc', 'generated/%%FILENAME%%_rc.py'],
+        ['modules/*/*.ui', '%%DIRNAME%%/generated/%%FILENAME%%_ui.py'],
+        ['modules/*/resources/*.qrc', '%%DIRNAME%%/generated/%%FILENAME%%_rc.py']
+    ])
+
+    _assert_path_does_not_exist(tmpdir.join("generated"))
+    _assert_path_does_not_exist(tmpdir.join("generated/main_ui.py"))
+
+    _assert_path_exists(tmpdir.join("another_directory").join("generated"))
+    _assert_path_exists(tmpdir.join("another_directory").join("generated/main_ui.py"))
+
+
+
+
+


### PR DESCRIPTION
Targets issue #36 

Adds the function `resolvePath()` to replace the previously used `os.path.isabs()`, as the latter uses `os.getcwd()` as reference to resolve relative paths, which is incorrect if the script is launched by any other folder that the one containing the configuration file.

However, `resolvePath()` does not strictly require the configuration file path, but can receive any base path as input. For now, if a configuration file was not given, I pass `os.getcwd()` to simulate the old behavior. I wonder whether passing the path to the script (so `os.path.dirname(os.path.realpath(__file__))`) would be more reasonable, but this can be discussed in a separate issue.

`resolvePath()` also detects and returns absolute paths unmodified.